### PR TITLE
bittern_cache_kmod: Include linux/vmalloc.h.

### DIFF
--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache.h
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache.h
@@ -37,6 +37,7 @@
 #include <linux/spinlock.h>
 #include <linux/stringify.h>
 #include <linux/uuid.h>
+#include <linux/vmalloc.h>
 #include <linux/workqueue.h>
 #include <linux/interrupt.h>
 


### PR DESCRIPTION
This patch fixes build errors on Linux 4.2.

bittern_cache_module_ctr.c: In function ‘cache_ctr’:
bittern_cache_module_ctr.c:774:7: error: implicit declaration of function ‘vzalloc’ [-Werror=implicit-function-declaration]
  bc = vzalloc(sizeof(struct bittern_cache));
       ^

https://github.com/twitter/bittern/issues/6

Signed-off-by: Vinson Lee vlee@twitter.com
