### PR TITLE
bittern_cache_kmod: Indent with tabs where possible.

### DIFF
--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_main.h
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_main.h
@@ -385,8 +385,8 @@ extern void cached_dev_do_make_request(struct bittern_cache *bc,
 /*! defer generic_make_request() to thread (workqueue) */
 extern void cached_dev_make_request_defer(struct bittern_cache *bc,
 					  struct work_item *wi,
-				          int datadir,
-				          bool set_original_bio);
+					  int datadir,
+					  bool set_original_bio);
 
 /*! main state machine */
 extern void cache_state_machine(struct bittern_cache *bc,

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_main_subr.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_main_subr.c
@@ -1254,9 +1254,9 @@ void cached_dev_make_request_defer(struct bittern_cache *bc,
 	atomic_inc(&bc->bc_make_request_wq_count);
 	wi->wi_ts_workqueue = current_kernel_time_nsec();
 
-        /* set up args for cache_make_request */
-        wi->bi_datadir = datadir;
-        wi->bi_set_original_bio = set_original_bio;
+	/* set up args for cache_make_request */
+	wi->bi_datadir = datadir;
+	wi->bi_set_original_bio = set_original_bio;
 
 	/* defer to worker thread, which will start io */
 	INIT_WORK(&wi->wi_work, cached_dev_make_request_worker);


### PR DESCRIPTION
Fix checkpatch.pl warnings.

Signed-off-by: Vinson Lee vlee@twitter.com
