### PR TITLE
bitter_cache_kmod: Fix checkpatch trailing statements error.

### DIFF
--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_linux.h
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_linux.h
@@ -111,7 +111,8 @@ static inline void atomic64_set_if_higher(atomic64_t *v, long long new)
 				__stringify(__assert_expr__));              \
 		BUG();                                                      \
 		/* should never reach this */                               \
-		for (;;) ;                                                  \
+		for (;;)                                                    \
+			;                                                   \
 	}                                                                   \
 } while (0)
 


### PR DESCRIPTION
Fixes checkpatch.pl "trailing statements should be on next line" error.

Signed-off-by: Vinson Lee vlee@twitter.com
