### PR TITLE
err handling 12i (depends on err 11): add error injection

### DIFF
--- a/bittern-cache/scripts/bc_control.sh
+++ b/bittern-cache/scripts/bc_control.sh
@@ -346,8 +346,9 @@ do_get() {
 	__cache_device_size=$(($__cache_device_size / 1024))
 	echo "	cache_device_size = $__cache_device_size mbytes"
 
-	echo "error_state:"
+	echo "error:"
 	echo "	error_state = $(get_cache_conf error_state)"
+	echo "	error_injection = $(get_cache_conf error_injection)"
 
 	echo "cache blocks:"
 	echo "	current_clean_blocks = $(get_cache_stats valid_clean_cache_entries)"
@@ -609,6 +610,10 @@ do_set() {
 		do_set_check_value
 		set_cache_conf error_state $VALUE_OPTION
 		;;
+	"error_injection")
+		do_set_check_value
+		set_cache_conf error_injection $VALUE_OPTION
+		;;
 	*)
 		echo $0: unrecognized "--set" option
 		exit 1
@@ -622,7 +627,7 @@ do_set() {
 check_set_priv() {
 	local __set_option=$*
 	case "$__set_option" in
-	"error_state"|"disable_req_fua")
+	"error_*"|"disable_req_fua")
 		if [ -z "$FORCE_OPTION" ]
 		then
 cat<<EOF

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache.h
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache.h
@@ -455,6 +455,20 @@ enum error_injection {
 	EI_MAIN_5,
 	EI_MAIN_6,
 	EI_MAIN_7,
+	EI_SM_1,
+	EI_SM_2,
+	EI_SM_3,
+	EI_SM_4,
+	EI_SM_5,
+	EI_SM_6,
+	EI_SM_7,
+	EI_SM_8,
+	EI_SM_9,
+	EI_SM_10,
+	EI_SM_11,
+	EI_SM_12,
+	EI_SM_13,
+	EI_SM_14, /*X*/
 	/*! leave this last */
 	EI_MAX,
 };

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache.h
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache.h
@@ -468,7 +468,42 @@ enum error_injection {
 	EI_SM_11,
 	EI_SM_12,
 	EI_SM_13,
-	EI_SM_14, /*X*/
+	EI_SM_14,
+	EI_I_15,
+	EI_I_16,
+	EI_I_17,
+	EI_M_18,
+	EI_B_1,
+	EI_B_2,
+	EI_B_3,
+	EI_P_1,
+	EI_P_2,
+	EI_P_3,
+	EI_P_4,
+	EI_P_5,
+	EI_P_6,
+	EI_P_7,
+	EI_P_8,
+	EI_P_9,
+	EI_P_10,
+	EI_P_11,
+	EI_P_12,
+	EI_P_13,
+	EI_P_14,
+	EI_P_15,
+	EI_P_16,
+	EI_P_17,
+	EI_P_18,
+	EI_P_19,
+	EI_P_20,
+	EI_PB_1,
+	EI_PB_2,
+	EI_PB_3,
+	EI_PB_4,
+	EI_PB_5,
+	EI_PB_6,
+	EI_PB_7,
+	EI_PB_8,
 	/*! leave this last */
 	EI_MAX,
 };
@@ -1100,8 +1135,10 @@ static inline int __inject_error(struct bittern_cache *bc,
 		   errno);
 	return errno;
 }
-#define inject_error(__bc, __ei, __err) \
+#define inject_error_e(__bc, __ei, __err) \
 		__inject_error((__bc), (__ei), (__err), -EL2NSYNC)
+#define inject_error(__bc, __ei) \
+		__inject_error((__bc), (__ei), 0, -EL2NSYNC)
 
 /*
  * red-black tree operations

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_bgwriter_kt.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_bgwriter_kt.c
@@ -38,7 +38,7 @@ void cache_bgwriter_io_end(struct bittern_cache *bc,
 		 "writeback-done, err=%d",
 		 err);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error_e(bc, EI_B_1, err);
 	if (err == 0) {
 		/*
 		 * Normal IO path.
@@ -237,14 +237,13 @@ int cache_bgwriter_io_start_one(struct bittern_cache *bc,
 	/*
 	 * allocate work_item and initialize it
 	 */
-	wi = work_item_allocate(bc,
-				cache_block,
-				NULL,
-				(WI_FLAG_BIO_NOT_CLONED |
-				 WI_FLAG_XID_USE_CACHE_BLOCK));
-	/*! \todo: error injection */
+	if (!inject_error(bc, EI_B_2))
+		wi = work_item_allocate(bc,
+					cache_block,
+					NULL,
+					(WI_FLAG_BIO_NOT_CLONED |
+					 WI_FLAG_XID_USE_CACHE_BLOCK));
 	if (wi == NULL) {
-		/*! \todo should make this a common function */
 		bc->error_state = ES_ERROR_FAIL_ALL;
 		cache_state_transition_final(bc,
 					     cache_block,
@@ -269,9 +268,8 @@ int cache_bgwriter_io_start_one(struct bittern_cache *bc,
 				 cache_block,
 				 NULL,
 				 &wi->wi_pmem_ctx);
-	/*! \todo: error injection */
+	ret = inject_error_e(bc, EI_B_3, ret);
 	if (ret != 0) {
-		/*! \todo should make this a common function */
 		bc->error_state = ES_ERROR_FAIL_ALL;
 		cache_state_transition_final(bc,
 					     cache_block,

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_main.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_main.c
@@ -438,7 +438,47 @@ void cache_state_machine(struct bittern_cache *bc,
 		 bc, wi, cache_block, wi->wi_original_bio, wi->wi_cloned_bio,
 		 "enter, err=%d",
 		 err);
-	err = inject_error_e(bc, EI_MAIN_1, err);
+
+	/*
+	 * only do error injection for non-initial states
+	 */
+	switch (cache_block->bcb_state) {
+	case S_CLEAN_READ_HIT_CPF_CACHE_END:
+	case S_DIRTY_READ_HIT_CPF_CACHE_END:
+	case S_CLEAN_READ_MISS_CPF_DEVICE_END:
+	case S_CLEAN_READ_MISS_CPT_CACHE_END:
+	case S_DIRTY_WRITE_MISS_CPT_CACHE_END:
+	case S_CLEAN_WRITE_MISS_CPT_DEVICE_END:
+	case S_CLEAN_WRITE_HIT_CPT_DEVICE_END:
+	case S_CLEAN_WRITE_MISS_CPT_CACHE_END:
+	case S_CLEAN_WRITE_HIT_CPT_CACHE_END:
+	case S_CLEAN_P_WRITE_HIT_CPT_DEVICE_END:
+	case S_CLEAN_P_WRITE_HIT_CPT_CACHE_END:
+	case S_DIRTY_P_WRITE_HIT_CPT_CACHE_START: /* not an initial state */
+	case S_C2_DIRTY_P_WRITE_HIT_CPT_CACHE_START: /* not an initial state */
+	case S_DIRTY_WRITE_HIT_CPT_CACHE_END:
+	case S_C2_DIRTY_WRITE_HIT_CPT_CACHE_END:
+	case S_DIRTY_P_WRITE_HIT_CPT_CACHE_END:
+	case S_C2_DIRTY_P_WRITE_HIT_CPT_CACHE_END:
+	case S_CLEAN_P_WRITE_MISS_CPF_DEVICE_END:
+	case S_DIRTY_P_WRITE_MISS_CPF_DEVICE_END:
+	case S_CLEAN_P_WRITE_MISS_CPT_DEVICE_END:
+	case S_CLEAN_P_WRITE_MISS_CPT_CACHE_END:
+	case S_DIRTY_P_WRITE_MISS_CPT_CACHE_END:
+	case S_DIRTY_WRITEBACK_CPF_CACHE_END:
+	case S_DIRTY_WRITEBACK_INV_CPF_CACHE_END:
+	case S_DIRTY_WRITEBACK_CPT_DEVICE_END:
+	case S_DIRTY_WRITEBACK_INV_CPT_DEVICE_END:
+	case S_DIRTY_WRITEBACK_UPD_METADATA_END:
+	case S_DIRTY_WRITEBACK_INV_UPD_METADATA_END:
+	case S_CLEAN_INVALIDATE_END:
+	case S_DIRTY_INVALIDATE_END:
+		err = inject_error_e(bc, EI_MAIN_1, err);
+		break;
+	default:
+		break;
+	}
+
 	if (err != 0) {
 		/*
 		 * This is generic state machine code, so the actual error

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_main.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_main.c
@@ -79,7 +79,7 @@ void cached_dev_bypass_endio(struct bio *cloned_bio, int err)
 
 	work_item_free(bc, wi);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_MAIN_0, err);
 	if (err != 0) {
 		ASSERT(err < 0);
 		BT_DEV_TRACE(BT_LEVEL_ERROR, bc, NULL, NULL, NULL, NULL,
@@ -438,7 +438,7 @@ void cache_state_machine(struct bittern_cache *bc,
 		 bc, wi, cache_block, wi->wi_original_bio, wi->wi_cloned_bio,
 		 "enter, err=%d",
 		 err);
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_MAIN_1, err);
 	if (err != 0) {
 		/*
 		 * This is generic state machine code, so the actual error
@@ -1695,7 +1695,8 @@ void cache_map_workfunc_handle_bypass(struct bittern_cache *bc, struct bio *bio)
 				NULL,
 				bio,
 				(WI_FLAG_BIO_CLONED | WI_FLAG_XID_NEW));
-	/*TODO_ADD_ERROR_INJECTION*/
+	if (inject_error(bc, EI_MAIN_2, 0))
+		wi = NULL;
 	if (wi == NULL) {
 		BT_DEV_TRACE(BT_LEVEL_ERROR, bc, NULL, NULL, NULL, NULL,
 			     "cannot allocate work_item for %s bypass",
@@ -1732,7 +1733,8 @@ void cache_map_workfunc_handle_bypass(struct bittern_cache *bc, struct bio *bio)
 	 * clone bio
 	 */
 	cloned_bio = bio_clone(bio, GFP_NOIO);
-	/*TODO_ADD_ERROR_INJECTION*/
+	if (inject_error(bc, EI_MAIN_3, 0))
+		cloned_bio = NULL;
 	if (cloned_bio == NULL) {
 		BT_DEV_TRACE(BT_LEVEL_ERROR, bc, NULL, NULL, NULL, NULL,
 			     "cannot clone bio for %s bypass",
@@ -1851,7 +1853,8 @@ int cache_map_workfunc_hit(struct bittern_cache *bc,
 				bio,
 				(WI_FLAG_BIO_CLONED |
 				 WI_FLAG_XID_NEW));
-	/*TODO_ADD_ERROR_INJECTION*/
+	if (inject_error(bc, EI_MAIN_4, 0))
+		wi = NULL;
 	if (wi == NULL) {
 		BT_DEV_TRACE(BT_LEVEL_ERROR, bc, NULL, NULL, NULL, NULL,
 			     "cannot allocate work_item for %s hit",
@@ -1882,7 +1885,7 @@ int cache_map_workfunc_hit(struct bittern_cache *bc,
 				 cache_block,
 				 cloned_cache_block,
 				 &wi->wi_pmem_ctx);
-	/*TODO_ADD_ERROR_INJECTION*/
+	ret = inject_error(bc, EI_MAIN_5, ret);
 	if (ret != 0) {
 		BT_DEV_TRACE(BT_LEVEL_ERROR, bc, NULL, NULL, NULL, NULL,
 			     "cannot setup pmem_context for %s hit",
@@ -2028,7 +2031,8 @@ void cache_map_workfunc_miss(struct bittern_cache *bc,
 				bio,
 				(WI_FLAG_BIO_CLONED |
 				 WI_FLAG_XID_NEW));
-	/*TODO_ADD_ERROR_INJECTION*/
+	if (inject_error(bc, EI_MAIN_6, 0))
+		wi = NULL;
 	if (wi == NULL) {
 		BT_DEV_TRACE(BT_LEVEL_ERROR, bc, NULL, NULL, NULL, NULL,
 			     "cannot allocate work_item for %s miss",
@@ -2059,7 +2063,7 @@ void cache_map_workfunc_miss(struct bittern_cache *bc,
 				 cache_block,
 				 NULL,
 				 &wi->wi_pmem_ctx);
-	/*TODO_ADD_ERROR_INJECTION*/
+	ret = inject_error(bc, EI_MAIN_7, ret);
 	if (ret != 0) {
 		BT_DEV_TRACE(BT_LEVEL_ERROR, bc, NULL, NULL, NULL, NULL,
 			     "cannot setup pmem_context for %s miss",

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_main_subr.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_main_subr.c
@@ -1120,7 +1120,7 @@ void cached_dev_do_make_request(struct bittern_cache *bc,
 				int datadir,
 				bool set_original_bio)
 {
-	struct bio *bio;
+	struct bio *bio = NULL;
 	struct cache_block *cache_block;
 
 	ASSERT_BITTERN_CACHE(bc);
@@ -1143,8 +1143,8 @@ void cached_dev_do_make_request(struct bittern_cache *bc,
 	ASSERT(wi->wi_cache_block == cache_block);
 	ASSERT(datadir == READ || datadir == WRITE);
 
-	bio = bio_alloc(GFP_NOIO, 1);
-	/*TODO_ADD_ERROR_INJECTION*/
+	if (!inject_error(bc, EI_M_18))
+		bio = bio_alloc(GFP_NOIO, 1);
 	if (bio == NULL) {
 		BT_DEV_TRACE(BT_LEVEL_ERROR, bc, NULL, cache_block, NULL, NULL,
 			     "cannot allocate bio, wi=%p",

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_module.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_module.c
@@ -379,6 +379,21 @@ static int param_get_error_state(struct bittern_cache *bc)
 	return (int)bc->error_state;
 }
 
+/*! only allow setting of error injection. do not allow reset. */
+static int param_set_error_injection(struct bittern_cache *bc, int value)
+{
+	bc->error_injection = value;
+	printk_info("%s: set error_injection=%d\n",
+		    bc->bc_name,
+		    bc->error_injection);
+	return 0;
+}
+
+static int param_get_error_injection(struct bittern_cache *bc)
+{
+	return (int)bc->error_injection;
+}
+
 static int control_dump_blocks_clean(struct bittern_cache *bc, int value)
 {
 	return cache_dump_blocks(bc, "clean", value);
@@ -630,6 +645,17 @@ struct cache_conf_param_entry cache_conf_param_list[] = {
 		.cache_conf_max = ES_ERROR_FAIL_ALL,
 		.cache_conf_setup_function = param_set_error_state,
 		.cache_conf_show_function = param_get_error_state,
+	},
+	/*
+	 * error injection
+	 */
+	{
+		.cache_conf_name = "error_injection",
+		.cache_conf_type = CONF_TYPE_INT,
+		.cache_conf_min = EI_NONE,
+		.cache_conf_max = EI_MAX,
+		.cache_conf_setup_function = param_set_error_injection,
+		.cache_conf_show_function = param_get_error_injection,
 	},
 	/*
 	 * control function -- invalidate cache blocks.

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_invalidate.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_invalidate.c
@@ -64,10 +64,11 @@ void sm_invalidate_end(struct bittern_cache *bc,
 {
 	struct cache_block *cache_block = wi->wi_cache_block;
 
+	err = inject_error_e(bc, EI_SM_14, err);
+
 	M_ASSERT(wi->wi_original_bio == NULL);
 	M_ASSERT(wi->wi_cloned_bio == NULL);
 	M_ASSERT(wi->wi_original_cache_block == NULL);
-
 	ASSERT(cache_block->bcb_state == S_CLEAN_INVALIDATE_END ||
 	       cache_block->bcb_state == S_DIRTY_INVALIDATE_END);
 	BT_TRACE(BT_LEVEL_TRACE2, bc, wi, cache_block, NULL, NULL,

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_pwrite.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_pwrite.c
@@ -233,7 +233,7 @@ void sm_pwrite_miss_copy_to_device_end(struct bittern_cache *bc,
 				S_DIRTY_P_WRITE_MISS_CPF_DEVICE_END,
 				S_DIRTY_P_WRITE_MISS_CPT_CACHE_END);
 
-	err = inject_error(bc, EI_SM_1, err);
+	err = inject_error_e(bc, EI_SM_1, err);
 	if (err != 0) {
 		bc->error_state = ES_ERROR_FAIL_ALL;
 		/*
@@ -279,7 +279,7 @@ void sm_pwrite_miss_copy_to_cache_end(struct bittern_cache *bc,
 	BT_TRACE(BT_LEVEL_TRACE2, bc, wi, cache_block, bio, NULL,
 		 "copy-to-cache-end, err=%d",
 		 err);
-	err = inject_error(bc, EI_SM_2, err);
+	err = inject_error_e(bc, EI_SM_2, err);
 	if (err != 0) {
 		/*
 		 * Simply set error state, nothing special needs to handle

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_pwrite.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_pwrite.c
@@ -233,7 +233,7 @@ void sm_pwrite_miss_copy_to_device_end(struct bittern_cache *bc,
 				S_DIRTY_P_WRITE_MISS_CPF_DEVICE_END,
 				S_DIRTY_P_WRITE_MISS_CPT_CACHE_END);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_1, err);
 	if (err != 0) {
 		bc->error_state = ES_ERROR_FAIL_ALL;
 		/*
@@ -279,7 +279,7 @@ void sm_pwrite_miss_copy_to_cache_end(struct bittern_cache *bc,
 	BT_TRACE(BT_LEVEL_TRACE2, bc, wi, cache_block, bio, NULL,
 		 "copy-to-cache-end, err=%d",
 		 err);
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_2, err);
 	if (err != 0) {
 		/*
 		 * Simply set error state, nothing special needs to handle

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_read.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_read.c
@@ -88,7 +88,7 @@ void sm_read_hit_copy_from_cache_end(struct bittern_cache *bc,
 		 "bio_copy_from_cache, err=%d",
 		 err);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_3, err);
 
 	ASSERT(bc->bc_enable_extra_checksum_check == 0 ||
 	       bc->bc_enable_extra_checksum_check == 1);
@@ -123,9 +123,6 @@ void sm_read_hit_copy_from_cache_end(struct bittern_cache *bc,
 	ASSERT_WORK_ITEM(wi, bc);
 	ASSERT_BITTERN_CACHE(bc);
 	ASSERT_CACHE_BLOCK(cache_block, bc);
-
-	BT_TRACE(BT_LEVEL_TRACE1, bc, wi, cache_block, bio, wi->wi_cloned_bio,
-		 "io-done");
 	ASSERT((wi->wi_flags & WI_FLAG_BIO_CLONED) != 0);
 
 	spin_lock_irqsave(&cache_block->bcb_spinlock, cache_flags);
@@ -271,7 +268,7 @@ void sm_read_miss_copy_from_device_end(struct bittern_cache *bc,
 				S_CLEAN_READ_MISS_CPF_DEVICE_END,
 				S_CLEAN_READ_MISS_CPT_CACHE_END);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_4, err);
 	if (err != 0) {
 		/*
 		 * Easiest way to handle this error is in the final state
@@ -340,7 +337,7 @@ void sm_read_miss_copy_to_cache_end(struct bittern_cache *bc,
 		 "end, err=%d",
 		 err);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_5, err);
 
 	ASSERT_WORK_ITEM(wi, bc);
 	ASSERT_BITTERN_CACHE(bc);

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_read.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_read.c
@@ -88,7 +88,7 @@ void sm_read_hit_copy_from_cache_end(struct bittern_cache *bc,
 		 "bio_copy_from_cache, err=%d",
 		 err);
 
-	err = inject_error(bc, EI_SM_3, err);
+	err = inject_error_e(bc, EI_SM_3, err);
 
 	ASSERT(bc->bc_enable_extra_checksum_check == 0 ||
 	       bc->bc_enable_extra_checksum_check == 1);
@@ -268,7 +268,7 @@ void sm_read_miss_copy_from_device_end(struct bittern_cache *bc,
 				S_CLEAN_READ_MISS_CPF_DEVICE_END,
 				S_CLEAN_READ_MISS_CPT_CACHE_END);
 
-	err = inject_error(bc, EI_SM_4, err);
+	err = inject_error_e(bc, EI_SM_4, err);
 	if (err != 0) {
 		/*
 		 * Easiest way to handle this error is in the final state
@@ -337,7 +337,7 @@ void sm_read_miss_copy_to_cache_end(struct bittern_cache *bc,
 		 "end, err=%d",
 		 err);
 
-	err = inject_error(bc, EI_SM_5, err);
+	err = inject_error_e(bc, EI_SM_5, err);
 
 	ASSERT_WORK_ITEM(wi, bc);
 	ASSERT_BITTERN_CACHE(bc);

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_write.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_write.c
@@ -136,7 +136,7 @@ void sm_dirty_write_miss_copy_to_cache_end(struct bittern_cache *bc,
 		 bio,
 		 err);
 
-	err = inject_error(bc, EI_SM_9, err);
+	err = inject_error_e(bc, EI_SM_9, err);
 	if (err != 0) {
 		/*
 		 * simply set error state and let request terminate
@@ -367,7 +367,7 @@ void sm_clean_write_miss_copy_to_device_end(struct bittern_cache *bc,
 		 "copy-to-device-io-done, err=%d",
 		 err);
 
-	err = inject_error(bc, EI_SM_10, err);
+	err = inject_error_e(bc, EI_SM_10, err);
 	if (err != 0) {
 		/*
 		 * simply set error state and let request terminate
@@ -462,7 +462,7 @@ void sm_clean_write_miss_copy_to_cache_end(struct bittern_cache *bc,
 		 "copy-to-cache-end, err=%d",
 		 err);
 
-	err = inject_error(bc, EI_SM_11, err);
+	err = inject_error_e(bc, EI_SM_11, err);
 	if (err != 0) {
 		/*
 		 * simply set error state and let request terminate
@@ -654,7 +654,7 @@ sm_dirty_pwrite_hit_copy_to_cache_start(struct bittern_cache *bc,
 		ASSERT(original_cache_block->bcb_state ==
 		       S_CLEAN_INVALIDATE_START);
 
-	err = inject_error(bc, EI_SM_12, err);
+	err = inject_error_e(bc, EI_SM_12, err);
 	if (err != 0) {
 		bc->error_state = ES_ERROR_FAIL_ALL;
 		/*
@@ -840,7 +840,7 @@ void sm_dirty_write_hit_copy_to_cache_end(struct bittern_cache *bc,
 		 "copy_to_cache_end, err=%d",
 		 err);
 
-	err = inject_error(bc, EI_SM_13, err);
+	err = inject_error_e(bc, EI_SM_13, err);
 	if (err != 0) {
 		/*
 		 * simply set error state and let request terminate

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_write.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_write.c
@@ -136,7 +136,7 @@ void sm_dirty_write_miss_copy_to_cache_end(struct bittern_cache *bc,
 		 bio,
 		 err);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_9, err);
 	if (err != 0) {
 		/*
 		 * simply set error state and let request terminate
@@ -367,7 +367,7 @@ void sm_clean_write_miss_copy_to_device_end(struct bittern_cache *bc,
 		 "copy-to-device-io-done, err=%d",
 		 err);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_10, err);
 	if (err != 0) {
 		/*
 		 * simply set error state and let request terminate
@@ -462,7 +462,7 @@ void sm_clean_write_miss_copy_to_cache_end(struct bittern_cache *bc,
 		 "copy-to-cache-end, err=%d",
 		 err);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_11, err);
 	if (err != 0) {
 		/*
 		 * simply set error state and let request terminate
@@ -654,7 +654,7 @@ sm_dirty_pwrite_hit_copy_to_cache_start(struct bittern_cache *bc,
 		ASSERT(original_cache_block->bcb_state ==
 		       S_CLEAN_INVALIDATE_START);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_12, err);
 	if (err != 0) {
 		bc->error_state = ES_ERROR_FAIL_ALL;
 		/*
@@ -840,7 +840,7 @@ void sm_dirty_write_hit_copy_to_cache_end(struct bittern_cache *bc,
 		 "copy_to_cache_end, err=%d",
 		 err);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_13, err);
 	if (err != 0) {
 		/*
 		 * simply set error state and let request terminate

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_writeback.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_writeback.c
@@ -110,7 +110,7 @@ void sm_writeback_copy_from_cache_end(struct bittern_cache *bc,
 	atomic_set_if_higher(&bc->bc_highest_pending_cached_device_requests,
 			     val);
 
-	err = inject_error(bc, EI_SM_6, err);
+	err = inject_error_e(bc, EI_SM_6, err);
 	if (err != 0) {
 		/*
 		 * Easiest thing to do is to just call the end state
@@ -159,7 +159,7 @@ void sm_writeback_copy_to_device_end(struct bittern_cache *bc,
 	ASSERT_CACHE_BLOCK(cache_block, bc);
 	ASSERT_WORK_ITEM(wi, bc);
 
-	err = inject_error(bc, EI_SM_7, err);
+	err = inject_error_e(bc, EI_SM_7, err);
 	if (err != 0) {
 		bc->error_state = ES_ERROR_FAIL_ALL;
 		cache_bgwriter_io_end(bc, wi, cache_block, err);
@@ -202,7 +202,7 @@ void sm_writeback_update_metadata_end(struct bittern_cache *bc,
 	struct bio *bio = wi->wi_original_bio;
 	struct cache_block *cache_block = wi->wi_cache_block;
 
-	err = inject_error(bc, EI_SM_8, err);
+	err = inject_error_e(bc, EI_SM_8, err);
 
 	M_ASSERT(wi->wi_original_bio == NULL);
 	M_ASSERT(wi->wi_cloned_bio == NULL);

--- a/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_writeback.c
+++ b/bittern-cache/src/bittern_cache_kmod/bittern_cache_sm_writeback.c
@@ -110,7 +110,7 @@ void sm_writeback_copy_from_cache_end(struct bittern_cache *bc,
 	atomic_set_if_higher(&bc->bc_highest_pending_cached_device_requests,
 			     val);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_6, err);
 	if (err != 0) {
 		/*
 		 * Easiest thing to do is to just call the end state
@@ -159,7 +159,7 @@ void sm_writeback_copy_to_device_end(struct bittern_cache *bc,
 	ASSERT_CACHE_BLOCK(cache_block, bc);
 	ASSERT_WORK_ITEM(wi, bc);
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_7, err);
 	if (err != 0) {
 		bc->error_state = ES_ERROR_FAIL_ALL;
 		cache_bgwriter_io_end(bc, wi, cache_block, err);
@@ -202,7 +202,7 @@ void sm_writeback_update_metadata_end(struct bittern_cache *bc,
 	struct bio *bio = wi->wi_original_bio;
 	struct cache_block *cache_block = wi->wi_cache_block;
 
-	/*TODO_ADD_ERROR_INJECTION*/
+	err = inject_error(bc, EI_SM_8, err);
 
 	M_ASSERT(wi->wi_original_bio == NULL);
 	M_ASSERT(wi->wi_cloned_bio == NULL);


### PR DESCRIPTION
err handling 12i (depends on err 11): add error injection.
bc_control.sh can be used to view error injection state and to inject a new error.
